### PR TITLE
모바일에서 네비게이션의 z값에 의해서 채널톡이 안 보이고 작동하지 않던 이슈 수정

### DIFF
--- a/style.css
+++ b/style.css
@@ -41,7 +41,8 @@
   width: 100%;
   height: 80px;
   background-color: white;
-  z-index: 10000000;
+  z-index: 10000;
+  transform: translateZ(10000px);
 }
 
 .pn-top a {


### PR DESCRIPTION
## PR 내용 설명
`.pn-top` 의 `z-index` 값이 채널톡보다 커서 네비게이션이 열렸을 때 채널톡 버튼을 가리고 있었습니다.
아이폰에서는 `.pn-top` 에 `transform: translateZ` 값이 설정되어 있지 않아서 버튼만 보이는 상태 였습니다.

## 테스트 방법

개발자 도구로 css 수정해봤을 때 정상적으로 작동하였습니다.

https://user-images.githubusercontent.com/78350101/224208467-77b39384-6953-4a39-bdda-c6fb1a5fb4bb.mov


## 관련 Swit 태스크 링크

(태스크는 없습니다.)
관련 메시지: https://app.swit.io/privatenote/channel/211101064528406Ossx/chat?msg_view=230310020020gK6XYHK
