### PR TITLE
.pn-top trasnform: translateZ 값 제거

### DIFF
--- a/style.css
+++ b/style.css
@@ -42,7 +42,6 @@
   height: 80px;
   background-color: white;
   z-index: 10000;
-  transform: translateZ(10000px);
 }
 
 .pn-top a {


### PR DESCRIPTION
## PR 내용 설명
`.pn-top` 의 `transform: translateZ` 값이 추가되니 우측 사이드바의 위치가 상단으로 이동되서 제거했습니다.

## 테스트 방법

개발자도구로 확인해봤습니다.

## 관련 Swit 태스크 링크

(태스크는 없습니다.)